### PR TITLE
Remove windows builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -32,20 +32,7 @@ builds:
     goarch:
       - amd64
       - arm64
-  - id: "windows"
-    env:
-      - CGO_ENABLED=0
-    mod_timestamp: "{{ .CommitTimestamp }}"
-    flags:
-      - -trimpath
-    ldflags:
-      - -s -w -X "pkg/version.version={{.Version}}" -X "pkg/version.commit={{.Commit}}" -X "pkg/version.date={{.Date}}"
-    binary: "{{ .ProjectName }}"
-    goos:
-      - windows
-    goarch:
-      - amd64
-      - arm64
+
 archives:
   - id: linux
     format: tar.gz
@@ -59,12 +46,6 @@ archives:
     wrap_in_directory: true
     builds:
       - "darwin"
-  - id: windows
-    format: tar.gz
-    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
-    wrap_in_directory: true
-    builds:
-      - "windows"
 
 kos:
   - working_dir: .

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,7 @@
-# Prometheus Exporter Release Process
+# Slotalk Release Process
 
 The repo uses [goreleaser](https://goreleaser.com/) and [ko](https://ko.build/) to release the different artifacts.
-To make a new release just create a new git tag, this will trigger a new Github action release [workflow](https://github.com/tfadeyi/sloth-simple-comments/blob/main/.github/workflows/release.yml).
+To make a new release just create a new git tag, this will trigger a new Github action release [workflow](https://github.com/tfadeyi/slotalk/blob/main/.github/workflows/release.yml).
 
 ```shell
 git tag -a v0.1.0 -m "First release"


### PR DESCRIPTION
<!--
By submitting a pull request to this repository, you agree to the terms within the project's Code of Conduct: https://github.com/tfadeyi/slotalk/blob/main/CODE_OF_CONDUCT.md.
-->

### 📋 Changes
* Remove windows builds from release pipeline.

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 🧪 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📚 References

Currently the tool probably won't work on windows, so I'm removing it from the builds.

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- StackOverflow answer
- Related pull requests/issues from other repositories
-->


