### PR TITLE
Update go module name to slotalk

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,44 @@ so I wanted try my hand on building something for developers.
 ## Prerequisites
 
 * [Sloth CLI](https://github.com/slok/sloth)
+* [Go](https://go.dev/doc/install) (optional)
+* [Nix](https://zero-to-nix.com/start/install) (optional)
 
 ## TL;DR
 
-1. Add comments to your source code. See [Declarative Comments](#Declarative Comments).
-2. Download a pre-compiled binary from the release page.
-    ```shell
-        curl -LJO https://github.com/tfadeyi/slotalk/releases/download/v0.0.2/slotalk-linux-amd64.tar.gz && \
-        tar -xzvf slotalk-linux-amd64.tar.gz && \
-        cd slotalk-linux-amd64
-    ```
+1. Add comments to your source code. See [Declarative Comments](#Declarative-Comments).
+
+2. Slotalk Installation
+
+   **Go install**
+
+   If go is present on the host machine, you can just download the required binaries.
+   
+   ```shell
+   # install the latest version of slotalk
+   go install github.com/tfadeyi/slotalk@latest
+   # (OPTIONAL) install the latest version of sloth
+   go install github.com/slok/sloth/cmd/sloth@latest
+   ```
+
+   **Nix**
+
+   If nix is present on the host machine, you can run the tool in the development shell
+   
+   ```shell
+   # creates a nix development shell with slotalk and sloth
+   nix develop github:tfadeyi/slotalk
+   ```
+
+   **Pre-released binaries**
+
+   Download a pre-compiled binary from the release page.
+   ```shell
+     curl -LJO https://github.com/tfadeyi/slotalk/releases/download/v0.0.2/slotalk-linux-amd64.tar.gz && \
+     tar -xzvf slotalk-linux-amd64.tar.gz && \
+     cd slotalk-linux-amd64
+   ```
+
 3. Run `slotalk` init in the project's root. This will parse your comments and print to standard out.
     ```shell
     ./slotalk init
@@ -187,7 +215,6 @@ slos:
 This specification can then be passed to the Sloth CLI to generate Prometheus alerting groups.
 
 ```shell
-touch sloth_defs.yaml && \
 ./slotalk init > sloth_defs.yaml && sloth generate -i sloth_defs.yaml
 ```
 

--- a/cmd/options/spec/options.go
+++ b/cmd/options/spec/options.go
@@ -1,14 +1,15 @@
 package spec
 
 import (
+	"os"
+
 	multierr "github.com/hashicorp/go-multierror"
 	"github.com/juju/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	goaloe "github.com/tfadeyi/go-aloe"
-	"github.com/tfadeyi/sloth-simple-comments/internal/generate"
-	"github.com/tfadeyi/sloth-simple-comments/internal/parser/lang"
-	"os"
+	"github.com/tfadeyi/slotalk/internal/generate"
+	"github.com/tfadeyi/slotalk/internal/parser/lang"
 )
 
 type (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,7 +8,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/tfadeyi/sloth-simple-comments/internal/logging"
+	"github.com/tfadeyi/slotalk/internal/logging"
 )
 
 // rootCmd represents the base command when called without any subcommands

--- a/cmd/spec.go
+++ b/cmd/spec.go
@@ -4,6 +4,7 @@ import (
 	"io"
 
 	"github.com/spf13/cobra"
+	specoptions "github.com/tfadeyi/slotalk/cmd/options/spec"
 	"github.com/tfadeyi/slotalk/internal/generate"
 	"github.com/tfadeyi/slotalk/internal/logging"
 	"github.com/tfadeyi/slotalk/internal/parser"
@@ -11,7 +12,6 @@ import (
 	"github.com/tfadeyi/slotalk/internal/parser/options"
 	"github.com/tfadeyi/slotalk/internal/parser/strategy/golang"
 	"github.com/tfadeyi/slotalk/internal/parser/strategy/wasm"
-	specoptions "github.com/tfadeyi/slotalk/cmd/options/spec"
 )
 
 func specGenerateCmd() *cobra.Command {

--- a/cmd/spec.go
+++ b/cmd/spec.go
@@ -1,16 +1,17 @@
 package cmd
 
 import (
-	"github.com/spf13/cobra"
-	specoptions "github.com/tfadeyi/sloth-simple-comments/cmd/options/spec"
-	"github.com/tfadeyi/sloth-simple-comments/internal/generate"
-	"github.com/tfadeyi/sloth-simple-comments/internal/logging"
-	"github.com/tfadeyi/sloth-simple-comments/internal/parser"
-	"github.com/tfadeyi/sloth-simple-comments/internal/parser/lang"
-	"github.com/tfadeyi/sloth-simple-comments/internal/parser/options"
-	"github.com/tfadeyi/sloth-simple-comments/internal/parser/strategy/golang"
-	"github.com/tfadeyi/sloth-simple-comments/internal/parser/strategy/wasm"
 	"io"
+
+	"github.com/spf13/cobra"
+	"github.com/tfadeyi/slotalk/internal/generate"
+	"github.com/tfadeyi/slotalk/internal/logging"
+	"github.com/tfadeyi/slotalk/internal/parser"
+	"github.com/tfadeyi/slotalk/internal/parser/lang"
+	"github.com/tfadeyi/slotalk/internal/parser/options"
+	"github.com/tfadeyi/slotalk/internal/parser/strategy/golang"
+	"github.com/tfadeyi/slotalk/internal/parser/strategy/wasm"
+	specoptions "github.com/tfadeyi/slotalk/cmd/options/spec"
 )
 
 func specGenerateCmd() *cobra.Command {

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -2,8 +2,8 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/tfadeyi/sloth-simple-comments/internal/logging"
-	"github.com/tfadeyi/sloth-simple-comments/internal/version"
+	"github.com/tfadeyi/slotalk/internal/logging"
+	"github.com/tfadeyi/slotalk/internal/version"
 )
 
 var versionCmd = &cobra.Command{

--- a/default.nix
+++ b/default.nix
@@ -12,8 +12,8 @@
 }:
 
 pkgs.buildGoApplication {
-  pname = "slotalks";
-  version = "v0.0.1";
+  pname = "slotalk";
+  version = "v0.0.2";
   pwd = ./.;
   src = ./.;
   modules = ./gomod2nix.toml;

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module github.com/tfadeyi/sloth-simple-comments
+module github.com/tfadeyi/slotalk
 
-go 1.19
+go 1.20
 
 require (
 	github.com/alecthomas/participle/v2 v2.0.0

--- a/internal/parser/options/options.go
+++ b/internal/parser/options/options.go
@@ -1,9 +1,10 @@
 package options
 
 import (
-	"github.com/tfadeyi/sloth-simple-comments/internal/logging"
-	"github.com/tfadeyi/sloth-simple-comments/internal/parser/strategy"
 	"io"
+
+	"github.com/tfadeyi/slotalk/internal/logging"
+	"github.com/tfadeyi/slotalk/internal/parser/strategy"
 )
 
 type (

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/juju/errors"
 	sloth "github.com/slok/sloth/pkg/prometheus/api/v1"
-	"github.com/tfadeyi/sloth-simple-comments/internal/parser/options"
+	"github.com/tfadeyi/slotalk/internal/parser/options"
 )
 
 type (

--- a/internal/parser/strategy/golang/options.go
+++ b/internal/parser/strategy/golang/options.go
@@ -1,7 +1,7 @@
 package golang
 
 import (
-	"github.com/tfadeyi/sloth-simple-comments/internal/parser/options"
+	"github.com/tfadeyi/slotalk/internal/parser/options"
 )
 
 func Parser() options.Option {

--- a/internal/parser/strategy/golang/parser.go
+++ b/internal/parser/strategy/golang/parser.go
@@ -2,10 +2,6 @@ package golang
 
 import (
 	"context"
-	"github.com/juju/errors"
-	sloth "github.com/slok/sloth/pkg/prometheus/api/v1"
-	"github.com/tfadeyi/sloth-simple-comments/internal/logging"
-	"github.com/tfadeyi/sloth-simple-comments/internal/parser/grammar"
 	"go/ast"
 	goparser "go/parser"
 	"go/token"
@@ -14,6 +10,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/juju/errors"
+	sloth "github.com/slok/sloth/pkg/prometheus/api/v1"
+	"github.com/tfadeyi/slotalk/internal/logging"
+	"github.com/tfadeyi/slotalk/internal/parser/grammar"
 )
 
 type parser struct {

--- a/internal/parser/strategy/wasm/options.go
+++ b/internal/parser/strategy/wasm/options.go
@@ -1,6 +1,6 @@
 package wasm
 
-import "github.com/tfadeyi/sloth-simple-comments/internal/parser/options"
+import "github.com/tfadeyi/slotalk/internal/parser/options"
 
 func Parser() options.Option {
 	return func(e *options.Options) {

--- a/internal/parser/strategy/wasm/parser.go
+++ b/internal/parser/strategy/wasm/parser.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"log"
+	"os"
+
 	sloth "github.com/slok/sloth/pkg/prometheus/api/v1"
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/imports/assemblyscript"
-	"github.com/tfadeyi/sloth-simple-comments/internal/logging"
-	"log"
-	"os"
+	"github.com/tfadeyi/slotalk/internal/logging"
 )
 
 type parser struct {

--- a/main.go
+++ b/main.go
@@ -28,16 +28,17 @@ package main
 
 import (
 	"context"
-	"github.com/tfadeyi/sloth-simple-comments/cmd"
-	"github.com/tfadeyi/sloth-simple-comments/internal/logging"
 	"os"
 	"os/signal"
 	"syscall"
+
+	"github.com/tfadeyi/slotalk/cmd"
+	"github.com/tfadeyi/slotalk/internal/logging"
 )
 
 // @aloe name slotalk
 // @aloe url https://tfadeyi.github.io
-// @aloe version v0.0.1
+// @aloe version v0.0.2
 // @aloe description Generate Sloth SLO/SLI definitions from code annotations.
 
 func main() {

--- a/nix/devshell.toml
+++ b/nix/devshell.toml
@@ -1,3 +1,7 @@
+[[env]]
+name = "GOROOT"
+value = ""
+
 [devshell]
 name = "develpment-shell"
 motd = """{106}Nix Development Shell{reset}
@@ -21,6 +25,7 @@ Use CTRL-D to leave the shell
 """
 
 packages = [
+    "go",
     "prometheus",
     "gotools",
     "go-tools",
@@ -33,5 +38,4 @@ startup.gomarkdoc.text = "go install github.com/princjef/gomarkdoc/cmd/gomarkdoc
 startup.aloe.text = "go install github.com/tfadeyi/aloe-cli@latest"
 startup.sloth.text = "go install github.com/slok/sloth/cmd/sloth@latest"
 # change when you update the go module
-startup.slotalk.text = "go install github.com/tfadeyi/sloth-simple-comments@latest"
-startup.slotalk_alias.text = "alias slotalk='sloth-simple-comments'"
+startup.slotalk.text = "go install github.com/tfadeyi/slotalk@latest"


### PR DESCRIPTION
<!--
By submitting a pull request to this repository, you agree to the terms within the project's Code of Conduct: https://github.com/tfadeyi/slotalk/blob/main/CODE_OF_CONDUCT.md.
-->

### 📋 Changes
* Changes the go module to `slotalk` rather than `sloth-simple-comments`.
* Updates the README installation section.
* Small updates to the nix flake and devshell.

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 🧪 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- StackOverflow answer
- Related pull requests/issues from other repositories
-->


