### PR TITLE
Add support for service selector

### DIFF
--- a/cmd/options/init/README.md
+++ b/cmd/options/init/README.md
@@ -16,7 +16,7 @@ Package spec contains the different options present under the spec generation co
   - [func (o *Options) Prepare(cmd *cobra.Command) *Options](<#func-options-prepare>)
 
 
-## type [Options](<https://github.com/tfadeyi/sloth-simple-comments/blob/main/cmd/options/init/options.go#L19-L26>)
+## type [Options](<https://github.com/tfadeyi/sloth-simple-comments/blob/main/cmd/options/init/options.go#L19-L28>)
 
 Options is the list of options/flag available to the application, plus the clients needed by the application to function.
 
@@ -27,11 +27,13 @@ type Options struct {
     Source        string
     SrcLanguage   lang.Target
     Specification string
+    ToFile        bool
+    Service       string
     *common.Options
 }
 ```
 
-### func [New](<https://github.com/tfadeyi/sloth-simple-comments/blob/main/cmd/options/init/options.go#L30>)
+### func [New](<https://github.com/tfadeyi/sloth-simple-comments/blob/main/cmd/options/init/options.go#L32>)
 
 ```go
 func New(c *common.Options) *Options
@@ -39,7 +41,7 @@ func New(c *common.Options) *Options
 
 New creates a new instance of the application's options
 
-### func \(\*Options\) [Complete](<https://github.com/tfadeyi/sloth-simple-comments/blob/main/cmd/options/init/options.go#L43>)
+### func \(\*Options\) [Complete](<https://github.com/tfadeyi/sloth-simple-comments/blob/main/cmd/options/init/options.go#L45>)
 
 ```go
 func (o *Options) Complete() error
@@ -47,7 +49,7 @@ func (o *Options) Complete() error
 
 Complete initialises the components needed for the application to function given the options
 
-### func \(\*Options\) [Prepare](<https://github.com/tfadeyi/sloth-simple-comments/blob/main/cmd/options/init/options.go#L37>)
+### func \(\*Options\) [Prepare](<https://github.com/tfadeyi/sloth-simple-comments/blob/main/cmd/options/init/options.go#L39>)
 
 ```go
 func (o *Options) Prepare(cmd *cobra.Command) *Options

--- a/cmd/options/init/options.go
+++ b/cmd/options/init/options.go
@@ -23,6 +23,7 @@ type (
 		SrcLanguage   lang.Target
 		Specification string
 		ToFile        bool
+		Service       string
 		*common.Options
 	}
 )
@@ -108,5 +109,11 @@ func (o *Options) addAppFlags(fs *pflag.FlagSet) {
 		"to-file",
 		false,
 		"Print the generated specifications to file, under ./slo_definitions.",
+	)
+	fs.StringVar(
+		&o.Service,
+		"service",
+		"",
+		"Outputs only the selected service specification from the resulting parsed service specification.",
 	)
 }

--- a/internal/generate/README.md
+++ b/internal/generate/README.md
@@ -10,10 +10,19 @@ Package generate contains utilities to generate data from a given specification
 
 ## Index
 
+- [Constants](<#constants>)
 - [Variables](<#variables>)
 - [func IsValidOutputFormat(format string) bool](<#func-isvalidoutputformat>)
 - [func WriteSpecifications(writer io.Writer, header []byte, specs map[string]any, toFile bool, outputDirectory string, formats ...string) error](<#func-writespecifications>)
 
+
+## Constants
+
+DefaultServiceDefinitionDir is the default filename for the output file
+
+```go
+const DefaultServiceDefinitionDir = "slo_definitions"
+```
 
 ## Variables
 


### PR DESCRIPTION
Allows the user to select which service specification to output.

<!--
By submitting a pull request to this repository, you agree to the terms within the project's Code of Conduct: https://github.com/tfadeyi/slotalk/blob/main/CODE_OF_CONDUCT.md.
-->

### 📋 Changes

- Add the `--service` flag to the `init` command
- Add support to only output a specific service from the output list of specs.

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

### 🧪 Testing
- Manual testing, In a repo with multiple service specification we run `slotalk init --service privategpt1`, this will only return the `privategpt1` service specification.

```
./builds/slotalk init --dirs testdir --service privategpt1
2023/06/11 18:55:43 root/init: "level"=2 "msg"="Parsing source code for slo definitions" "directories"=["testdir"] "source"=""
2023/06/11 18:55:43 root/init: "level"=2 "msg"="Source code was parsed"
2023/06/11 18:55:43 root/init: "level"=2 "msg"="Printing result specification to stdout."
# Code generated by slotalk: https://github.com/tfadeyi/slotalk.
# DO NOT EDIT.
version: prometheus/v1
service: privategpt1
slos:
    - name: private-gpt-availability
      description: 95% of logins to the chat-gpt app should be successful.
      objective: 99
      sli:
        events:
            error_query: sum(rate(tenant_failed_login_operations_total{client="chat-gpt"}[{{.window}}])) OR on() vector(0)
            total_query: sum(rate(tenant_login_operations_total{client="chat-gpt"}[{{.window}}]))
      alerting:
        name: PrivateGPTAvailability
```
<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->

### 📚 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- StackOverflow answer
- Related pull requests/issues from other repositories
-->


